### PR TITLE
Update writeVTU.py

### DIFF
--- a/src/writeVTU.py
+++ b/src/writeVTU.py
@@ -167,7 +167,7 @@ class writeVTU:
         
         myfile.write('\n</Cells>')
         
-        myfile.write('\n<PointData>')
+        myfile.write('\n<PointData RationalWeights="RationalWeights">')
     
     # ======================================================================
         myfile.write('\n<DataArray type="%s" Name="%s" format="ascii">'%('Float64', 'RationalWeights'))


### PR DESCRIPTION
Fixed a problem where new versions of ParaView (/VTK Toolkit readers) cannot locate the array containing the rational weights automatically.